### PR TITLE
fix: ExpandableCalendar week header height wrong after textMonthFontS…

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -171,14 +171,22 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
 
   const [position, setPosition] = useState(numberOfDays ? Positions.CLOSED : initialPosition);
   const isOpen = position === Positions.OPEN;
+  const getTotalClosedHeight = () => {
+    if(theme) {
+      if(theme.textMonthFontSize) {
+        return KNOB_CONTAINER_HEIGHT + (theme.textMonthFontSize! > 16 ? (theme.textMonthFontSize! - 16) : 0)
+      }
+    }
+    return KNOB_CONTAINER_HEIGHT
+  }
   const getOpenHeight = () => {
     if (!horizontal) {
       return Math.max(constants.screenHeight, constants.screenWidth);
     }
-    return CLOSED_HEIGHT + (WEEK_HEIGHT * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 : 0);
+    return CLOSED_HEIGHT + (WEEK_HEIGHT * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 + getTotalClosedHeight() : 0);
   };
   const openHeight = useRef(getOpenHeight());
-  const closedHeight = useMemo(() => CLOSED_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob]);
+  const closedHeight = useMemo(() => CLOSED_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : constants.isAndroid ? getTotalClosedHeight() : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob]);
   const startHeight = useMemo(() => isOpen ? openHeight.current : closedHeight, [closedHeight, isOpen]);
   const _height = useRef(startHeight);
   const deltaY = useMemo(() => new Animated.Value(startHeight), [startHeight]);
@@ -281,6 +289,16 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   const handleScreenReaderStatus = (screenReaderEnabled: any) => {
     setScreenReaderEnabled(screenReaderEnabled);
   };
+
+  /** top calculation as per header height, total height & font size  */
+  const getTopPosition = () => {
+    if(theme) {
+      if(theme.textMonthFontSize) {
+        return theme.textMonthFontSize! > 16 ? closedHeight - HEADER_HEIGHT + 4 : HEADER_HEIGHT + 8
+      }
+    }
+    return HEADER_HEIGHT + 8
+  }
 
   /** Scroll */
 
@@ -546,7 +564,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     return (
       <Animated.View
         ref={weekCalendarWrapper}
-        style={weekCalendarStyle}
+        style={[weekCalendarStyle, {top: constants.isAndroid ? getTopPosition() : HEADER_HEIGHT + 9}]}
         pointerEvents={isOpen ? 'none' : 'auto'}
       >
         <WeekComponent


### PR DESCRIPTION
fixed: ExpandableCalendar week header height wrong after textMonthFontSize changed by calculating total height and subtracting total height to HEADER_HEIGHT to get the week height using default font size as 16 

<img width="853" alt="Screenshot 2024-01-05 at 11 14 43 AM" src="https://github.com/qburst/react-native-calendars-repo1/assets/151492137/bc71d346-ca39-4ae2-8460-8a8264494809">
<img width="984" alt="Screenshot 2024-01-05 at 11 15 49 AM" src="https://github.com/qburst/react-native-calendars-repo1/assets/151492137/8cf2249d-e5a1-481d-847d-04b1b6e78e30">
<img width="1006" alt="Screenshot 2024-01-05 at 11 16 04 AM" src="https://github.com/qburst/react-native-calendars-repo1/assets/151492137/dc135573-a6fd-4a97-aea9-362e65846062">
<img width="567" alt="Screenshot 2024-01-05 at 11 16 22 AM" src="https://github.com/qburst/react-native-calendars-repo1/assets/151492137/1ddea32e-362e-4c1d-b847-cc47117b205b">


